### PR TITLE
fix: allow crs-less files

### DIFF
--- a/rio_vrt/vrt.py
+++ b/rio_vrt/vrt.py
@@ -12,6 +12,9 @@ from rasterio.enums import ColorInterp
 
 from .enums import resolutions, types
 
+DEFAULT_CRS = rio.crs.CRS.from_epsg("4326")
+"The default crs to use in the vrt file if nothing specified in the sources."
+
 
 def _add_source_content(
     Source: ET.Element, src: rio.DatasetReader, type: str, xoff: str, yoff: str
@@ -77,7 +80,7 @@ def build_vrt(
 
     # read global informations from the first file
     with rio.open(files[0]) as f:
-        crs = f.crs
+        crs = f.crs or DEFAULT_CRS
         count = f.count
         dtypes = f.dtypes
         colorinterps = f.colorinterp
@@ -91,9 +94,10 @@ def build_vrt(
     # sanity checks
     for file in files:
         with rio.open(file) as f:
-            if f.crs != crs:
+            loc_crs = f.crs or DEFAULT_CRS
+            if loc_crs != crs:
                 raise ValueError(
-                    f'the crs ({f.crs}) from file "{file}" is not corresponding to the global one ({crs})'
+                    f'the crs ({loc_crs}) from file "{file}" is not corresponding to the global one ({crs})'
                 )
 
             if mosaic and f.count != count:

--- a/tests/test_rio_vrt/(6, 6)_vrt.vrt
+++ b/tests/test_rio_vrt/(6, 6)_vrt.vrt
@@ -29,7 +29,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -43,7 +43,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="8951" ySize="179"/>
    <NODATA>
@@ -57,7 +57,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="17902" ySize="179"/>
    <NODATA>
@@ -71,7 +71,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="26854" ySize="179"/>
    <NODATA>
@@ -85,7 +85,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="0" xSize="197" yOff="35805" ySize="2"/>
    <NODATA>
@@ -99,7 +99,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="9851" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -113,7 +113,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="9851" xSize="197" yOff="8951" ySize="179"/>
    <NODATA>
@@ -127,7 +127,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="9851" xSize="197" yOff="17902" ySize="179"/>
    <NODATA>
@@ -141,7 +141,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="9851" xSize="197" yOff="26854" ySize="179"/>
    <NODATA>
@@ -155,7 +155,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="9851" xSize="197" yOff="35805" ySize="2"/>
    <NODATA>
@@ -169,7 +169,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="19702" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -183,7 +183,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="19702" xSize="197" yOff="8951" ySize="179"/>
    <NODATA>
@@ -197,7 +197,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="19702" xSize="197" yOff="17902" ySize="179"/>
    <NODATA>
@@ -211,7 +211,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="19702" xSize="197" yOff="26854" ySize="179"/>
    <NODATA>
@@ -225,7 +225,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="19702" xSize="197" yOff="35805" ySize="2"/>
    <NODATA>
@@ -239,7 +239,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="29554" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -253,7 +253,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="29554" xSize="197" yOff="8951" ySize="179"/>
    <NODATA>
@@ -267,7 +267,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="29554" xSize="197" yOff="17902" ySize="179"/>
    <NODATA>
@@ -281,7 +281,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="29554" xSize="197" yOff="26854" ySize="179"/>
    <NODATA>
@@ -295,7 +295,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="29554" xSize="197" yOff="35805" ySize="2"/>
    <NODATA>
@@ -309,7 +309,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="39405" xSize="3" yOff="0" ySize="179"/>
    <NODATA>
@@ -323,7 +323,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="39405" xSize="3" yOff="8951" ySize="179"/>
    <NODATA>
@@ -337,7 +337,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="39405" xSize="3" yOff="17902" ySize="179"/>
    <NODATA>
@@ -351,7 +351,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="39405" xSize="3" yOff="26854" ySize="179"/>
    <NODATA>
@@ -365,7 +365,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="2"/>
+   <SourceProperties BlockXSize="3" BlockYSize="2" DataType="Byte" RasterXSize="3" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="2"/>
    <DstRect xOff="39405" xSize="3" yOff="35805" ySize="2"/>
    <NODATA>
@@ -393,7 +393,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -407,7 +407,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="8951" ySize="179"/>
    <NODATA>
@@ -421,7 +421,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="17902" ySize="179"/>
    <NODATA>
@@ -435,7 +435,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="26854" ySize="179"/>
    <NODATA>
@@ -449,7 +449,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="0" xSize="197" yOff="35805" ySize="2"/>
    <NODATA>
@@ -463,7 +463,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="9851" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -477,7 +477,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="9851" xSize="197" yOff="8951" ySize="179"/>
    <NODATA>
@@ -491,7 +491,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="9851" xSize="197" yOff="17902" ySize="179"/>
    <NODATA>
@@ -505,7 +505,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="9851" xSize="197" yOff="26854" ySize="179"/>
    <NODATA>
@@ -519,7 +519,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="9851" xSize="197" yOff="35805" ySize="2"/>
    <NODATA>
@@ -533,7 +533,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="19702" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -547,7 +547,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="19702" xSize="197" yOff="8951" ySize="179"/>
    <NODATA>
@@ -561,7 +561,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="19702" xSize="197" yOff="17902" ySize="179"/>
    <NODATA>
@@ -575,7 +575,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="19702" xSize="197" yOff="26854" ySize="179"/>
    <NODATA>
@@ -589,7 +589,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="19702" xSize="197" yOff="35805" ySize="2"/>
    <NODATA>
@@ -603,7 +603,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="29554" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -617,7 +617,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="29554" xSize="197" yOff="8951" ySize="179"/>
    <NODATA>
@@ -631,7 +631,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="29554" xSize="197" yOff="17902" ySize="179"/>
    <NODATA>
@@ -645,7 +645,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="29554" xSize="197" yOff="26854" ySize="179"/>
    <NODATA>
@@ -659,7 +659,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="29554" xSize="197" yOff="35805" ySize="2"/>
    <NODATA>
@@ -673,7 +673,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="39405" xSize="3" yOff="0" ySize="179"/>
    <NODATA>
@@ -687,7 +687,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="39405" xSize="3" yOff="8951" ySize="179"/>
    <NODATA>
@@ -701,7 +701,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="39405" xSize="3" yOff="17902" ySize="179"/>
    <NODATA>
@@ -715,7 +715,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="39405" xSize="3" yOff="26854" ySize="179"/>
    <NODATA>
@@ -729,7 +729,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="2"/>
+   <SourceProperties BlockXSize="3" BlockYSize="2" DataType="Byte" RasterXSize="3" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="2"/>
    <DstRect xOff="39405" xSize="3" yOff="35805" ySize="2"/>
    <NODATA>
@@ -757,7 +757,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -771,7 +771,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="8951" ySize="179"/>
    <NODATA>
@@ -785,7 +785,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="17902" ySize="179"/>
    <NODATA>
@@ -799,7 +799,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="26854" ySize="179"/>
    <NODATA>
@@ -813,7 +813,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="0" xSize="197" yOff="35805" ySize="2"/>
    <NODATA>
@@ -827,7 +827,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="9851" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -841,7 +841,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="9851" xSize="197" yOff="8951" ySize="179"/>
    <NODATA>
@@ -855,7 +855,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="9851" xSize="197" yOff="17902" ySize="179"/>
    <NODATA>
@@ -869,7 +869,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="9851" xSize="197" yOff="26854" ySize="179"/>
    <NODATA>
@@ -883,7 +883,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="9851" xSize="197" yOff="35805" ySize="2"/>
    <NODATA>
@@ -897,7 +897,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="19702" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -911,7 +911,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="19702" xSize="197" yOff="8951" ySize="179"/>
    <NODATA>
@@ -925,7 +925,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="19702" xSize="197" yOff="17902" ySize="179"/>
    <NODATA>
@@ -939,7 +939,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="19702" xSize="197" yOff="26854" ySize="179"/>
    <NODATA>
@@ -953,7 +953,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="19702" xSize="197" yOff="35805" ySize="2"/>
    <NODATA>
@@ -967,7 +967,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="29554" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -981,7 +981,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="29554" xSize="197" yOff="8951" ySize="179"/>
    <NODATA>
@@ -995,7 +995,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="29554" xSize="197" yOff="17902" ySize="179"/>
    <NODATA>
@@ -1009,7 +1009,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="29554" xSize="197" yOff="26854" ySize="179"/>
    <NODATA>
@@ -1023,7 +1023,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="29554" xSize="197" yOff="35805" ySize="2"/>
    <NODATA>
@@ -1037,7 +1037,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="39405" xSize="3" yOff="0" ySize="179"/>
    <NODATA>
@@ -1051,7 +1051,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="39405" xSize="3" yOff="8951" ySize="179"/>
    <NODATA>
@@ -1065,7 +1065,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="39405" xSize="3" yOff="17902" ySize="179"/>
    <NODATA>
@@ -1079,7 +1079,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="39405" xSize="3" yOff="26854" ySize="179"/>
    <NODATA>
@@ -1093,7 +1093,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="2"/>
+   <SourceProperties BlockXSize="3" BlockYSize="2" DataType="Byte" RasterXSize="3" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="2"/>
    <DstRect xOff="39405" xSize="3" yOff="35805" ySize="2"/>
    <NODATA>

--- a/tests/test_rio_vrt/average_vrt.vrt
+++ b/tests/test_rio_vrt/average_vrt.vrt
@@ -29,7 +29,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -43,7 +43,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -57,7 +57,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -71,7 +71,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -85,7 +85,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="0" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -99,7 +99,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -113,7 +113,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -127,7 +127,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -141,7 +141,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -155,7 +155,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="197" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -169,7 +169,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -183,7 +183,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -197,7 +197,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -211,7 +211,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -225,7 +225,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="394" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -239,7 +239,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -253,7 +253,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -267,7 +267,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -281,7 +281,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -295,7 +295,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="591" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -309,7 +309,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="0" ySize="179"/>
    <NODATA>
@@ -323,7 +323,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="179" ySize="179"/>
    <NODATA>
@@ -337,7 +337,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="358" ySize="179"/>
    <NODATA>
@@ -351,7 +351,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="537" ySize="179"/>
    <NODATA>
@@ -365,7 +365,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="2"/>
+   <SourceProperties BlockXSize="3" BlockYSize="2" DataType="Byte" RasterXSize="3" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="2"/>
    <DstRect xOff="788" xSize="3" yOff="716" ySize="2"/>
    <NODATA>
@@ -393,7 +393,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -407,7 +407,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -421,7 +421,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -435,7 +435,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -449,7 +449,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="0" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -463,7 +463,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -477,7 +477,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -491,7 +491,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -505,7 +505,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -519,7 +519,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="197" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -533,7 +533,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -547,7 +547,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -561,7 +561,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -575,7 +575,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -589,7 +589,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="394" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -603,7 +603,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -617,7 +617,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -631,7 +631,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -645,7 +645,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -659,7 +659,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="591" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -673,7 +673,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="0" ySize="179"/>
    <NODATA>
@@ -687,7 +687,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="179" ySize="179"/>
    <NODATA>
@@ -701,7 +701,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="358" ySize="179"/>
    <NODATA>
@@ -715,7 +715,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="537" ySize="179"/>
    <NODATA>
@@ -729,7 +729,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="2"/>
+   <SourceProperties BlockXSize="3" BlockYSize="2" DataType="Byte" RasterXSize="3" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="2"/>
    <DstRect xOff="788" xSize="3" yOff="716" ySize="2"/>
    <NODATA>
@@ -757,7 +757,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -771,7 +771,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -785,7 +785,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -799,7 +799,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -813,7 +813,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="0" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -827,7 +827,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -841,7 +841,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -855,7 +855,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -869,7 +869,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -883,7 +883,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="197" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -897,7 +897,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -911,7 +911,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -925,7 +925,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -939,7 +939,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -953,7 +953,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="394" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -967,7 +967,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -981,7 +981,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -995,7 +995,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -1009,7 +1009,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -1023,7 +1023,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="591" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -1037,7 +1037,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="0" ySize="179"/>
    <NODATA>
@@ -1051,7 +1051,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="179" ySize="179"/>
    <NODATA>
@@ -1065,7 +1065,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="358" ySize="179"/>
    <NODATA>
@@ -1079,7 +1079,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="537" ySize="179"/>
    <NODATA>
@@ -1093,7 +1093,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="2"/>
+   <SourceProperties BlockXSize="3" BlockYSize="2" DataType="Byte" RasterXSize="3" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="2"/>
    <DstRect xOff="788" xSize="3" yOff="716" ySize="2"/>
    <NODATA>

--- a/tests/test_rio_vrt/complete_vrt.vrt
+++ b/tests/test_rio_vrt/complete_vrt.vrt
@@ -29,7 +29,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -43,7 +43,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -57,7 +57,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -71,7 +71,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -85,7 +85,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="0" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -99,7 +99,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -113,7 +113,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -127,7 +127,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -141,7 +141,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -155,7 +155,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="197" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -169,7 +169,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -183,7 +183,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -197,7 +197,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -211,7 +211,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -225,7 +225,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="394" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -239,7 +239,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -253,7 +253,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -267,7 +267,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -281,7 +281,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -295,7 +295,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="591" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -309,7 +309,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="0" ySize="179"/>
    <NODATA>
@@ -323,7 +323,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="179" ySize="179"/>
    <NODATA>
@@ -337,7 +337,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="358" ySize="179"/>
    <NODATA>
@@ -351,7 +351,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="537" ySize="179"/>
    <NODATA>
@@ -365,7 +365,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="2"/>
+   <SourceProperties BlockXSize="3" BlockYSize="2" DataType="Byte" RasterXSize="3" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="2"/>
    <DstRect xOff="788" xSize="3" yOff="716" ySize="2"/>
    <NODATA>
@@ -393,7 +393,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -407,7 +407,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -421,7 +421,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -435,7 +435,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -449,7 +449,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="0" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -463,7 +463,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -477,7 +477,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -491,7 +491,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -505,7 +505,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -519,7 +519,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="197" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -533,7 +533,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -547,7 +547,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -561,7 +561,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -575,7 +575,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -589,7 +589,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="394" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -603,7 +603,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -617,7 +617,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -631,7 +631,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -645,7 +645,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -659,7 +659,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="591" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -673,7 +673,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="0" ySize="179"/>
    <NODATA>
@@ -687,7 +687,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="179" ySize="179"/>
    <NODATA>
@@ -701,7 +701,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="358" ySize="179"/>
    <NODATA>
@@ -715,7 +715,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="537" ySize="179"/>
    <NODATA>
@@ -729,7 +729,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="2"/>
+   <SourceProperties BlockXSize="3" BlockYSize="2" DataType="Byte" RasterXSize="3" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="2"/>
    <DstRect xOff="788" xSize="3" yOff="716" ySize="2"/>
    <NODATA>
@@ -757,7 +757,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -771,7 +771,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -785,7 +785,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -799,7 +799,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -813,7 +813,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="0" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -827,7 +827,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -841,7 +841,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -855,7 +855,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -869,7 +869,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -883,7 +883,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="197" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -897,7 +897,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -911,7 +911,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -925,7 +925,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -939,7 +939,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -953,7 +953,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="394" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -967,7 +967,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -981,7 +981,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -995,7 +995,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -1009,7 +1009,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -1023,7 +1023,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="591" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -1037,7 +1037,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="0" ySize="179"/>
    <NODATA>
@@ -1051,7 +1051,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="179" ySize="179"/>
    <NODATA>
@@ -1065,7 +1065,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="358" ySize="179"/>
    <NODATA>
@@ -1079,7 +1079,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="537" ySize="179"/>
    <NODATA>
@@ -1093,7 +1093,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="2"/>
+   <SourceProperties BlockXSize="3" BlockYSize="2" DataType="Byte" RasterXSize="3" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="2"/>
    <DstRect xOff="788" xSize="3" yOff="716" ySize="2"/>
    <NODATA>

--- a/tests/test_rio_vrt/highest_vrt.vrt
+++ b/tests/test_rio_vrt/highest_vrt.vrt
@@ -29,7 +29,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -43,7 +43,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -57,7 +57,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -71,7 +71,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -85,7 +85,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="0" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -99,7 +99,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -113,7 +113,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -127,7 +127,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -141,7 +141,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -155,7 +155,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="197" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -169,7 +169,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -183,7 +183,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -197,7 +197,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -211,7 +211,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -225,7 +225,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="394" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -239,7 +239,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -253,7 +253,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -267,7 +267,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -281,7 +281,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -295,7 +295,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="591" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -309,7 +309,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="0" ySize="179"/>
    <NODATA>
@@ -323,7 +323,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="179" ySize="179"/>
    <NODATA>
@@ -337,7 +337,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="358" ySize="179"/>
    <NODATA>
@@ -351,7 +351,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="537" ySize="179"/>
    <NODATA>
@@ -365,7 +365,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="2"/>
+   <SourceProperties BlockXSize="3" BlockYSize="2" DataType="Byte" RasterXSize="3" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="2"/>
    <DstRect xOff="788" xSize="3" yOff="716" ySize="2"/>
    <NODATA>
@@ -393,7 +393,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -407,7 +407,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -421,7 +421,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -435,7 +435,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -449,7 +449,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="0" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -463,7 +463,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -477,7 +477,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -491,7 +491,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -505,7 +505,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -519,7 +519,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="197" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -533,7 +533,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -547,7 +547,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -561,7 +561,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -575,7 +575,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -589,7 +589,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="394" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -603,7 +603,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -617,7 +617,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -631,7 +631,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -645,7 +645,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -659,7 +659,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="591" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -673,7 +673,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="0" ySize="179"/>
    <NODATA>
@@ -687,7 +687,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="179" ySize="179"/>
    <NODATA>
@@ -701,7 +701,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="358" ySize="179"/>
    <NODATA>
@@ -715,7 +715,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="537" ySize="179"/>
    <NODATA>
@@ -729,7 +729,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="2"/>
+   <SourceProperties BlockXSize="3" BlockYSize="2" DataType="Byte" RasterXSize="3" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="2"/>
    <DstRect xOff="788" xSize="3" yOff="716" ySize="2"/>
    <NODATA>
@@ -757,7 +757,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -771,7 +771,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -785,7 +785,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -799,7 +799,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -813,7 +813,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="0" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -827,7 +827,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -841,7 +841,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -855,7 +855,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -869,7 +869,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -883,7 +883,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="197" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -897,7 +897,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -911,7 +911,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -925,7 +925,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -939,7 +939,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -953,7 +953,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="394" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -967,7 +967,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -981,7 +981,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -995,7 +995,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -1009,7 +1009,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -1023,7 +1023,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="591" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -1037,7 +1037,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="0" ySize="179"/>
    <NODATA>
@@ -1051,7 +1051,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="179" ySize="179"/>
    <NODATA>
@@ -1065,7 +1065,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="358" ySize="179"/>
    <NODATA>
@@ -1079,7 +1079,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="537" ySize="179"/>
    <NODATA>
@@ -1093,7 +1093,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="2"/>
+   <SourceProperties BlockXSize="3" BlockYSize="2" DataType="Byte" RasterXSize="3" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="2"/>
    <DstRect xOff="788" xSize="3" yOff="716" ySize="2"/>
    <NODATA>

--- a/tests/test_rio_vrt/hollow_vrt.vrt
+++ b/tests/test_rio_vrt/hollow_vrt.vrt
@@ -29,7 +29,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -43,7 +43,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -57,7 +57,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -71,7 +71,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -85,7 +85,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="197" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -99,7 +99,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -113,7 +113,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -127,7 +127,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -141,7 +141,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -155,7 +155,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="591" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -169,7 +169,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="179" ySize="179"/>
    <NODATA>
@@ -183,7 +183,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="537" ySize="179"/>
    <NODATA>
@@ -211,7 +211,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -225,7 +225,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -239,7 +239,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -253,7 +253,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -267,7 +267,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="197" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -281,7 +281,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -295,7 +295,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -309,7 +309,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -323,7 +323,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -337,7 +337,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="591" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -351,7 +351,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="179" ySize="179"/>
    <NODATA>
@@ -365,7 +365,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="537" ySize="179"/>
    <NODATA>
@@ -393,7 +393,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -407,7 +407,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -421,7 +421,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -435,7 +435,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -449,7 +449,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="197" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -463,7 +463,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -477,7 +477,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -491,7 +491,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -505,7 +505,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -519,7 +519,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="591" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -533,7 +533,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="179" ySize="179"/>
    <NODATA>
@@ -547,7 +547,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="537" ySize="179"/>
    <NODATA>

--- a/tests/test_rio_vrt/lowest_vrt.vrt
+++ b/tests/test_rio_vrt/lowest_vrt.vrt
@@ -29,7 +29,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -43,7 +43,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -57,7 +57,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -71,7 +71,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -85,7 +85,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="0" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -99,7 +99,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -113,7 +113,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -127,7 +127,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -141,7 +141,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -155,7 +155,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="197" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -169,7 +169,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -183,7 +183,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -197,7 +197,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -211,7 +211,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -225,7 +225,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="394" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -239,7 +239,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -253,7 +253,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -267,7 +267,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -281,7 +281,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -295,7 +295,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="591" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -309,7 +309,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="0" ySize="179"/>
    <NODATA>
@@ -323,7 +323,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="179" ySize="179"/>
    <NODATA>
@@ -337,7 +337,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="358" ySize="179"/>
    <NODATA>
@@ -351,7 +351,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="537" ySize="179"/>
    <NODATA>
@@ -365,7 +365,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="2"/>
+   <SourceProperties BlockXSize="3" BlockYSize="2" DataType="Byte" RasterXSize="3" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="2"/>
    <DstRect xOff="788" xSize="3" yOff="716" ySize="2"/>
    <NODATA>
@@ -393,7 +393,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -407,7 +407,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -421,7 +421,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -435,7 +435,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -449,7 +449,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="0" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -463,7 +463,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -477,7 +477,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -491,7 +491,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -505,7 +505,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -519,7 +519,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="197" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -533,7 +533,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -547,7 +547,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -561,7 +561,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -575,7 +575,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -589,7 +589,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="394" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -603,7 +603,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -617,7 +617,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -631,7 +631,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -645,7 +645,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -659,7 +659,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="591" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -673,7 +673,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="0" ySize="179"/>
    <NODATA>
@@ -687,7 +687,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="179" ySize="179"/>
    <NODATA>
@@ -701,7 +701,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="358" ySize="179"/>
    <NODATA>
@@ -715,7 +715,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="537" ySize="179"/>
    <NODATA>
@@ -729,7 +729,7 @@
    <SourceBand>
     2
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="2"/>
+   <SourceProperties BlockXSize="3" BlockYSize="2" DataType="Byte" RasterXSize="3" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="2"/>
    <DstRect xOff="788" xSize="3" yOff="716" ySize="2"/>
    <NODATA>
@@ -757,7 +757,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -771,7 +771,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -785,7 +785,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -799,7 +799,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -813,7 +813,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="0" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -827,7 +827,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -841,7 +841,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -855,7 +855,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -869,7 +869,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -883,7 +883,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="197" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -897,7 +897,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -911,7 +911,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -925,7 +925,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -939,7 +939,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -953,7 +953,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="394" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -967,7 +967,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="0" ySize="179"/>
    <NODATA>
@@ -981,7 +981,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="179" ySize="179"/>
    <NODATA>
@@ -995,7 +995,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="358" ySize="179"/>
    <NODATA>
@@ -1009,7 +1009,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="537" ySize="179"/>
    <NODATA>
@@ -1023,7 +1023,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="591" xSize="197" yOff="716" ySize="2"/>
    <NODATA>
@@ -1037,7 +1037,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="0" ySize="179"/>
    <NODATA>
@@ -1051,7 +1051,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="179" ySize="179"/>
    <NODATA>
@@ -1065,7 +1065,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="358" ySize="179"/>
    <NODATA>
@@ -1079,7 +1079,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="537" ySize="179"/>
    <NODATA>
@@ -1093,7 +1093,7 @@
    <SourceBand>
     3
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="2"/>
+   <SourceProperties BlockXSize="3" BlockYSize="2" DataType="Byte" RasterXSize="3" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="2"/>
    <DstRect xOff="788" xSize="3" yOff="716" ySize="2"/>
    <NODATA>

--- a/tests/test_rio_vrt/stack_vrt.vrt
+++ b/tests/test_rio_vrt/stack_vrt.vrt
@@ -17,7 +17,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="179" ySize="179"/>
   </ComplexSource>
@@ -30,7 +30,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="0" xSize="197" yOff="537" ySize="179"/>
   </ComplexSource>
@@ -43,7 +43,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="0" ySize="179"/>
   </ComplexSource>
@@ -56,7 +56,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="197" xSize="197" yOff="358" ySize="179"/>
   </ComplexSource>
@@ -69,7 +69,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="197" xSize="197" yOff="716" ySize="2"/>
   </ComplexSource>
@@ -82,7 +82,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="179" ySize="179"/>
   </ComplexSource>
@@ -95,7 +95,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="394" xSize="197" yOff="537" ySize="179"/>
   </ComplexSource>
@@ -108,7 +108,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="0" ySize="179"/>
   </ComplexSource>
@@ -121,7 +121,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
    <DstRect xOff="591" xSize="197" yOff="358" ySize="179"/>
   </ComplexSource>
@@ -134,7 +134,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="197" RasterYSize="2"/>
+   <SourceProperties BlockXSize="197" BlockYSize="2" DataType="Byte" RasterXSize="197" RasterYSize="2"/>
    <SrcRect xOff="0" xSize="197" yOff="0" ySize="2"/>
    <DstRect xOff="591" xSize="197" yOff="716" ySize="2"/>
   </ComplexSource>
@@ -147,7 +147,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="179" ySize="179"/>
   </ComplexSource>
@@ -160,7 +160,7 @@
    <SourceBand>
     1
    </SourceBand>
-   <SourceProperties DataType="Byte" RasterXSize="3" RasterYSize="179"/>
+   <SourceProperties BlockXSize="3" BlockYSize="3" DataType="Byte" RasterXSize="3" RasterYSize="179"/>
    <SrcRect xOff="0" xSize="3" yOff="0" ySize="179"/>
    <DstRect xOff="788" xSize="3" yOff="537" ySize="179"/>
   </ComplexSource>


### PR DESCRIPTION
This should fix #22.

Weirdly on every tests and without changing anything on my side every Image creation is now adding the `blockXSize` and `blockYSize` all the time. As the source image of the tests have not changed for the past 4 years, my guess is that the latest version of rasterio is now infering these values if not available. @gboeing, can you confirm that this branch is not impacting your results ? 